### PR TITLE
Fix border radius parsing on web.

### DIFF
--- a/code/utils/styleParsing.ts
+++ b/code/utils/styleParsing.ts
@@ -442,7 +442,10 @@ export const getBorderRadius = (style) => {
         "borderBottomRightRadius",
         "borderBottomLeftRadius",
     ]) {
-        if (typeof style[prop] === "string") {
+        if (
+            typeof style[prop] === "string" ||
+            (typeof style[prop] === "number" && !Number.isNaN(style[prop]))
+        ) {
             result[prop] = style[prop]
         }
     }


### PR DESCRIPTION
This fixes #15. In framer web, `borderBottomLeftRadius`, etc. will be numbers, while on the desktop, they are strings. This change allows `Switch` to handle both of these cases. 